### PR TITLE
ci(glulx): retry the glulxercise battery, not just pin its seed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,17 +123,31 @@ jobs:
       # every section, and the certification asserts the exact
       # tally -- 70 sections passed, no failures, and the closing
       # verdict spoken -- through the same stdio session a player
-      # would use. The seed is pinned: the random section does
-      # statistical checks, and an honest unseeded stream fails
-      # them by pure chance every few dozen runs -- which twice
-      # read as a phantom regression on a green change.
+      # would use.
+      #
+      # --seed 777 pins every section that draws on the session
+      # stream, but RandomTest reseeds from real entropy itself
+      # (`@setrandom 0`) and then checks the histogram against wide
+      # but finite bounds -- it prints its own warning that it
+      # "may, very occasionally, fail through sheer bad luck." So
+      # the battery is retried: a real regression fails every
+      # attempt, one unlucky histogram does not. True determinism
+      # for RandomTest is issue #316.
       - name: Glulxercise, the whole battery
         run: |
-          out="$(echo all | uv run voxam --seed 777 entharion/glulx-checkers/glulxercise-r13-s241202.ulx)"
-          echo "$out" | tail -3
-          test "$(echo "$out" | grep -c '^Passed\.$')" -eq 70
-          echo "$out" | grep -q "All tests passed."
-          ! echo "$out" | grep -q "FAILED"
+          for attempt in 1 2 3; do
+            out="$(echo all | uv run voxam --seed 777 entharion/glulx-checkers/glulxercise-r13-s241202.ulx)"
+            if [ "$(echo "$out" | grep -c '^Passed\.$')" -eq 70 ] \
+              && echo "$out" | grep -q "All tests passed." \
+              && ! echo "$out" | grep -q "FAILED"; then
+              echo "$out" | tail -3
+              exit 0
+            fi
+            echo "::warning::glulxercise attempt $attempt did not certify"
+            echo "$out" | tail -5
+          done
+          echo "::error::glulxercise did not certify in 3 attempts"
+          exit 1
 
   build:
     name: Build distribution


### PR DESCRIPTION
## What

Wrap the glulxercise certification step in a 3-attempt retry. Pass on the first clean run; fail only if all three miss.

## Why

The failing check on #315 was glulxercise's `RandomTest` reporting `2 tests failed overall: random (2)` — on a branch that touches only the desktop shell. It was a statistical false failure, and #211's `--seed 777` pin cannot prevent it:

- `RandomTest` executes `@setrandom 0` itself (`entharion/glulx-checkers-source/glulxercise-r13-s241202.inf:4774`), which per spec discards any seed and pulls real OS entropy (`src/voxam/glulx/rng.py:91`).
- It then checks a 240-draw histogram against ~4σ bounds across ~25 buckets.
- The section prints its own warning: *"Tests may, very occasionally, fail through sheer bad luck. If so, try this test again."*

`--seed 777` still pins every other section, so a genuine `@random` regression fails all three attempts — only an unlucky histogram is retried away.

## Follow-up

Real determinism for `RandomTest` (folding an in-story reseed back into the session seed when `--seed` was given) is #316. If that lands, this retry can come back out.