### PR TITLE
fix(screen): the painted terminal follows the window it is given, not the one it booted against

### DIFF
--- a/src/voxam/painter.py
+++ b/src/voxam/painter.py
@@ -344,8 +344,15 @@ class ScreenFrontend:
         # session once a machine exists: called on each heartbeat
         # of an infinite wait. None waits the old blocking way.
         self.idle: Callable[[], None] | None = None
+        # The size read here is a starting guess: a terminal slow
+        # to answer -- iTerm2 mid-launch, a webview shell -- leaves
+        # it at the fallback. _sync_terminal_size re-reads it before
+        # the first paint and on every idle beat, reshaping the
+        # model and, through on_resize, the §8.4 header when it
+        # moves. Set by the machine; None leaves the header be.
         self.screen_columns = terminal.width or FALLBACK_COLUMNS
         self.screen_lines = terminal.height or FALLBACK_LINES
+        self.on_resize: Callable[[], None] | None = None
         self._model = ScreenModel(
             columns=self.screen_columns, lines=self.screen_lines, version=version
         )
@@ -555,11 +562,12 @@ class ScreenFrontend:
 
         Without an idle callback this is a plain blocking read.
         With one, the wait is chopped into heartbeats: each expiry
-        lets the machine attend to background work -- an ended
-        sound's routine (§9.4.4) -- before listening again. One
-        heartbeat's answer comes back as it is; None still means
-        "nothing usable yet", and every caller already waits that
-        out.
+        lets the terminal be re-measured -- a window resized while
+        the player thinks at a prompt redraws within the beat --
+        and the machine attend to background work, an ended sound's
+        routine (§9.4.4), before listening again. One heartbeat's
+        answer comes back as it is; None still means "nothing
+        usable yet", and every caller already waits that out.
         """
 
         if self.idle is None:
@@ -568,6 +576,9 @@ class ScreenFrontend:
         key = self._translated_key(IDLE_HEARTBEAT)
 
         if key is None:
+            if self._sync_terminal_size():
+                self._repaint()
+
             self.idle()
 
         return key
@@ -650,6 +661,9 @@ class ScreenFrontend:
             key = self._translated_key(wait)
 
             if key is None and self.idle is not None:
+                if self._sync_terminal_size():
+                    self._repaint()
+
                 self.idle()
 
             return key
@@ -822,11 +836,38 @@ class ScreenFrontend:
         of the picture for the same reason.
         """
 
+        self._sync_terminal_size()
+
         for row in range(1, self._model.lines + 1):
             self._paint_row(row)
 
+    def _sync_terminal_size(self) -> bool:
+        """Match the model to the terminal's current size (§8.4).
+
+        A dimension the terminal reports as 0 is one it is not
+        answering yet, so it is left as it stands rather than
+        snapped to a guess. Returns whether anything moved.
+        """
+
+        columns = self._terminal.width or self.screen_columns
+        lines = self._terminal.height or self.screen_lines
+
+        if columns == self.screen_columns and lines == self.screen_lines:
+            return False
+
+        self.screen_columns = columns
+        self.screen_lines = lines
+        self._model.resize(columns, lines)
+
+        if self.on_resize is not None:
+            self.on_resize()
+
+        return True
+
     def _repaint(self) -> None:
         """Redraw every damaged row, then park the cursor."""
+
+        self._sync_terminal_size()
 
         for row in self._model.sweep():
             self._paint_row(row)

--- a/src/voxam/screen.py
+++ b/src/voxam/screen.py
@@ -368,6 +368,60 @@ class ScreenModel:
         self._grid[row - 1][column - 1] = cell
         self._damage.add(row)
 
+    def resize(self, columns: int, lines: int) -> None:
+        """Reshape the grid to a new screen size (§8.4).
+
+        A terminal the player resizes mid-session lands here -- and
+        so does the first honest size, when the frontend booted
+        against a terminal too slow to report one. The overlap of
+        the old grid is kept, top left aligned, so the status line
+        and the upper window stay where they were; the fresh margin
+        blanks in the current background. The split and both cursors
+        are drawn back inside the new bounds, and every row is left
+        damaged so the painter redraws the whole screen. A size that
+        did not actually change does nothing.
+        """
+
+        columns = max(1, columns)
+        lines = max(1, lines)
+
+        if columns == self._columns and lines == self._lines:
+            return
+
+        self._flush()
+
+        old = self._grid
+        blank = self._blank_cell()
+        self._grid = [
+            [
+                old[row][column] if row < len(old) and column < len(old[row]) else blank
+                for column in range(columns)
+            ]
+            for row in range(lines)
+        ]
+
+        self._columns = columns
+        self._lines = lines
+        self._split = max(0, min(self._split, lines - self._upper_top() + 1))
+
+        reach = max(1, lines - self._upper_top() + 1)
+        upper_row, upper_column = self._upper_cursor
+        self._upper_cursor = (
+            min(max(upper_row, 1), reach),
+            min(max(upper_column, 1), columns),
+        )
+
+        floor = min(self._lower_top(), lines)
+        lower_row, lower_column = self._lower_cursor
+        self._lower_cursor = (
+            min(max(lower_row, floor), lines),
+            min(max(lower_column, 1), columns),
+        )
+
+        self._scroll_due = False
+        self._fed = 0
+        self._damage = set(range(1, lines + 1))
+
     def split_window(self, height: int) -> None:
         """Resize the upper window to the given height (§8.7.2.1).
 

--- a/src/voxam/zmachine/machine.py
+++ b/src/voxam/zmachine/machine.py
@@ -678,6 +678,14 @@ class Machine:
         self.discontinuity = False
 
         self._declare_capabilities()
+
+        # A painted terminal can change size mid-session; when it
+        # does it calls back, so the §8.4 screen fields keep the
+        # truth. Frontends that never resize never set this, and
+        # nothing before Version 4 has the fields to keep.
+        if hasattr(self._frontend, "on_resize"):
+            self._frontend.on_resize = self._refresh_screen_fields
+
         self._start_execution()
 
     def _start_execution(self) -> None:
@@ -793,6 +801,34 @@ class Machine:
                     # re-stamped here after restart and restore,
                     # as the contract asks (arc_image: part A).
                     header.declare_pictures(available=self._frontend.has_arc_images)
+
+    def _refresh_screen_fields(self) -> None:
+        """Re-stamp the §8.4 screen size after a frontend resize.
+
+        The painted terminal calls this when the player resizes the
+        window. Only the size and unit fields move -- the
+        interpreter identity and the capability bits the boot set
+        do not. Before Version 4 there are no such fields, and a
+        resize is felt only in the freshly reshaped screen model.
+        """
+
+        header = self._memory.header
+
+        if header.version < SCREEN_FIELDS_VERSION:
+            return
+
+        header.declare_screen_size(
+            lines=self._frontend.screen_lines,
+            columns=self._frontend.screen_columns,
+        )
+
+        if header.version >= FONT_FIELDS_VERSION:
+            font_width, font_height = self._unit_metrics()
+
+            header.declare_screen_units(
+                width=self._frontend.screen_columns * font_width,
+                height=self._frontend.screen_lines * font_height,
+            )
 
     def snapshot(self) -> Snapshot:
         """Capture the entire state of play (§6.1, §6.1.1).

--- a/tests/test_painter.py
+++ b/tests/test_painter.py
@@ -873,3 +873,65 @@ def test_cursor_position_reads_the_model() -> None:
     frontend.set_cursor(2, 5)
 
     assert_that(frontend.cursor_position()).is_equal_to((2, 5))
+
+
+# A terminal slow to report its size -- iTerm2 mid-launch -- leaves
+# the model at the fallback; the size read before the first paint
+# reshapes it to the truth (§8.4).
+def test_clear_takes_the_terminal_at_its_current_size() -> None:
+    frontend, _out = painted(version=3)
+    frontend._terminal.width = 25
+    frontend._terminal.height = 5
+
+    frontend.clear()
+
+    assert_that(frontend.model.columns).is_equal_to(25)
+    assert_that(frontend.model.lines).is_equal_to(5)
+
+
+# A resize noticed on a write reshapes the model before the row is
+# painted.
+def test_a_resize_before_a_write_reshapes_the_model() -> None:
+    frontend, _out = painted(version=3)
+    frontend._terminal.width = 44
+    frontend._terminal.height = 10
+
+    frontend.write("resized")
+
+    assert_that(frontend.model.columns).is_equal_to(44)
+    assert_that(frontend.model.lines).is_equal_to(10)
+
+
+# A window resized while the player thinks at a prompt is caught on
+# the idle heartbeat: the model reshapes, the screen repaints, and
+# the on_resize hook fires for the header.
+def test_a_resize_between_keystrokes_reshapes_and_repaints() -> None:
+    terminal = StubTerminal([StubKey(""), StubKey("n")])
+    out: list[str] = []
+    frontend = ScreenFrontend(5, terminal=terminal, out=out.append)
+    frontend.idle = lambda: None
+    resizes: list[int] = []
+    frontend.on_resize = lambda: resizes.append(1)
+
+    terminal.width = 50
+    terminal.height = 12
+
+    assert_that(frontend.read_key()).is_equal_to("n")
+    assert_that(frontend.model.columns).is_equal_to(50)
+    assert_that(frontend.model.lines).is_equal_to(12)
+    assert_that(resizes).is_length(1)
+    assert_that("".join(out)).contains("<@0,0>")
+
+
+# A timed line read reshapes on its own heartbeat too, so Border
+# Zone's clock keeps ticking against a right-sized screen.
+def test_a_resize_during_a_timed_read_reshapes_too() -> None:
+    terminal = StubTerminal([StubKey(""), *typing("wait")])
+    out: list[str] = []
+    frontend = ScreenFrontend(5, terminal=terminal, out=out.append)
+    frontend.idle = lambda: None
+
+    terminal.width = 60
+
+    assert_that(frontend.read_line_until(9.0)).is_equal_to("wait")
+    assert_that(frontend.model.columns).is_equal_to(60)

--- a/tests/test_screen_model.py
+++ b/tests/test_screen_model.py
@@ -756,3 +756,74 @@ def test_a_form_renders_as_a_golden_grid() -> None:
     )
 
     assert_that(screen.rendered()).is_equal_to(expected)
+
+
+# A terminal the player resizes mid-session reshapes the grid: the
+# old top-left corner is kept -- the status line and the upper
+# window stay put -- and every row comes back damaged for a full
+# repaint (§8.4).
+def test_resize_keeps_the_top_left_and_damages_everything() -> None:
+    screen = ScreenModel(columns=40, lines=HEIGHT, version=3)
+    screen.show_status(Status("West of House", 1, 2, time_game=False))
+    screen.write("adventure")
+    screen.sweep()
+
+    screen.resize(50, 10)
+
+    assert_that(screen.columns).is_equal_to(50)
+    assert_that(screen.lines).is_equal_to(10)
+    assert_that(screen.row_text(1)).contains("West of House")
+    assert_that(screen.row_text(1)).contains("Score: 1  Moves: 2")
+    assert_that(screen.row_text(HEIGHT)).is_equal_to("adventure")
+    assert_that(screen.sweep()).is_equal_to(list(range(1, 11)))
+
+
+# Growing the screen blanks the fresh margin, both the new columns
+# on old rows and the new rows entirely.
+def test_resize_blanks_the_new_margin() -> None:
+    screen = small(version=5)
+
+    screen.resize(30, 10)
+
+    assert_that(screen.cell(1, 25).character).is_equal_to(" ")
+    assert_that(screen.row_text(10)).is_equal_to("")
+
+
+# A resize to the size already held is a no-op: nothing moves and
+# no row is damaged.
+def test_resize_to_the_same_size_does_nothing() -> None:
+    screen = small(version=3)
+    screen.sweep()
+
+    screen.resize(WIDTH, HEIGHT)
+
+    assert_that(screen.sweep()).is_empty()
+
+
+# Shrinking pulls the split and both cursors back inside the new
+# bounds (§8.7.2.1).
+def test_resize_smaller_reins_in_the_split_and_cursors() -> None:
+    screen = small(version=5)
+    screen.split_window(4)
+    screen.set_window(UPPER)
+    screen.set_cursor(4, WIDTH - 1)
+
+    screen.resize(8, 3)
+
+    assert_that(screen.split).is_equal_to(3)
+
+    row, column = screen.get_cursor()
+
+    assert_that(row).is_less_than_or_equal_to(3)
+    assert_that(column).is_less_than_or_equal_to(8)
+
+
+# The screen never shrinks below a single cell, whatever a broken
+# terminal reports.
+def test_resize_floors_at_one_by_one() -> None:
+    screen = small(version=3)
+
+    screen.resize(0, -5)
+
+    assert_that(screen.columns).is_equal_to(1)
+    assert_that(screen.lines).is_equal_to(1)

--- a/tests/zmachine/test_screen.py
+++ b/tests/zmachine/test_screen.py
@@ -699,3 +699,63 @@ def test_v6_erasure_polices_the_ninth_window() -> None:
 
     with pytest.raises(ZMachineScreenError, match="not one of the eight"):
         machine.run()
+
+
+class ResizableRecorder(ScreenRecorder):
+    """A screen recorder that also carries the resize callback.
+
+    The callback starts inert; the machine replaces it at boot, and
+    the tests below prove that by the header it re-stamps.
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.on_resize: Callable[[], None] = lambda: None
+
+
+# A frontend resize re-stamps the §8.4 screen fields: from Version
+# 4 the line and column bytes, and from Version 5 the unit words
+# besides (§8.4, §11.1).
+def test_a_frontend_resize_restamps_the_screen_header() -> None:
+    frontend = ResizableRecorder()
+    machine = Machine(screen_story(b"", version=5), frontend, lambda: "")
+
+    frontend.screen_lines = 40
+    frontend.screen_columns = 132
+    frontend.on_resize()
+
+    memory = machine.memory
+
+    assert_that(memory.read_byte(0x20)).is_equal_to(40)
+    assert_that(memory.read_byte(0x21)).is_equal_to(132)
+    assert_that(memory.read_word(0x22)).is_equal_to(132)
+    assert_that(memory.read_word(0x24)).is_equal_to(40)
+
+
+# Version 4 has the line and column bytes but no unit words: the
+# resize moves the two bytes and leaves $22 alone.
+def test_a_version_4_resize_moves_only_the_size_bytes() -> None:
+    frontend = ResizableRecorder()
+    machine = Machine(screen_story(b"", version=4), frontend, lambda: "")
+
+    frontend.screen_lines = 40
+    frontend.screen_columns = 132
+    frontend.on_resize()
+
+    memory = machine.memory
+
+    assert_that(memory.read_byte(0x20)).is_equal_to(40)
+    assert_that(memory.read_byte(0x21)).is_equal_to(132)
+    assert_that(memory.read_word(0x22)).is_equal_to(0)
+
+
+# Before Version 4 there are no such fields, so the resize callback
+# is a quiet no-op -- the reshaped model carries the change alone.
+def test_a_frontend_resize_is_a_no_op_before_version_4() -> None:
+    frontend = ResizableRecorder()
+    machine = Machine(screen_story(b"", version=3), frontend, lambda: "")
+
+    frontend.screen_lines = 40
+    frontend.on_resize()
+
+    assert_that(machine.memory.read_byte(0x20)).is_equal_to(0)


### PR DESCRIPTION
Closes #312.

## The bug

On a stable 121×29 iTerm2 window, the Version 3 status bar renders cut off — the grey reverse-video row stops around two-thirds across and `Score`/`Moves` sit well short of the right edge. Terminal.app and RetroTerm are fine.

## Root cause

`ScreenFrontend` read the terminal size once, in `__init__`, and froze it — there was no `SIGWINCH` handling and `ScreenModel` had no way to reshape. iTerm2's PTY size is not settled at the instant the frontend is constructed (Terminal.app / RetroTerm hand it over before `voxam` execs), so the read caught a stale value — the 80×24 terminfo default, when `TIOCGWINSZ` returns 0 — and every paint for the rest of the session used it. An 80-column status line on a 121-column window covers only the left two-thirds.

## Fix

- **`ScreenModel.resize(columns, lines)`** — reshapes the grid: the old top-left corner is kept (status line and upper window stay put), the new margin blanks in the current background, the split and both cursors are pulled inside the new bounds, every row is damaged. No-op on an unchanged size; floors at 1×1.
- **`ScreenFrontend` re-reads the size** before the first paint (`clear()`, which `cli.py` runs at session start — this corrects the iTerm2 startup case), on every `_repaint()`, and on the idle heartbeat during key/line/timed reads — so a window resized *while the player sits at a prompt* also redraws, within ~0.2s. A dimension reported as `0` is left as it stands rather than snapped to a guess.
- **`Machine._refresh_screen_fields`**, wired to `frontend.on_resize` at boot — re-stamps the §8.4 header size bytes ($20/$21, Version 4+) and unit words ($22/$24, Version 5+) on a resize. Version 3 (this bug) needs only the reshaped model.

Ordering: `_screen_frontend()` builds the frontend → `painted.clear()` re-syncs to the settled size → `Machine(...)` stamps the header from the corrected `screen_columns`. Nothing reads a dimension before it is right.

## Verification

`2036 passed`, 100% coverage, `mypy --strict` clean, `ruff` clean. zork1 / fixtures / arthur regtests pass; CZECH z3–z8 at their expected tallies.

## Follow-up (not here)

`glass.py:530` freezes the Version 6 pixel window's size the same way; that frontend resizes through `pygame.VIDEORESIZE` and is worth its own issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)