### PR TITLE
feat(glass): the pixel window wears a theme, gentle dark by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,7 +215,9 @@ is what keeps recordings deterministic. And `--graphics` opens
 the pygame window, which is the home of the Version 6 games, and
 a fine roomy home for the earlier ones too. `--zoom` sets how much
 of the desktop it takes (0.85 by default; `--zoom 0` keeps the
-classic compact 80 by 24).
+classic compact 80 by 24). `--theme` sets its ink and paper --
+`dark` by default, or `paper`, `sepia`, or `classic` for the old
+pure white on black.
 
 Glulx stories play the same way: a `.ulx` file or a packaged
 `.gblorb` is recognized by its own magic, and at a real terminal

--- a/src/voxam/cli.py
+++ b/src/voxam/cli.py
@@ -85,6 +85,12 @@ RECORDED_SEED_CEILING = 100_000
 # Where the browser face listens unless --port says otherwise.
 WEB_PORT = 8080
 
+# The graphics window's --theme choices, named here so the parser
+# needs no eager import of the optional glass. voxam.glass holds
+# their actual ink and paper, and a test keeps the two in step.
+THEME_CHOICES = ("classic", "dark", "paper", "sepia")
+DEFAULT_THEME = "dark"
+
 
 def main(argv: Sequence[str] | None = None) -> int:
     """Run the Voxam command line.
@@ -254,6 +260,12 @@ def main(argv: Sequence[str] | None = None) -> int:
         help="the desktop fraction the graphics window fills (0 keeps "
         "the classic compact size)",
     )
+    parser.add_argument(
+        "--theme",
+        choices=THEME_CHOICES,
+        default=DEFAULT_THEME,
+        help="the graphics window's ink and paper (default: %(default)s)",
+    )
     arguments = parser.parse_args(argv)
 
     if not arguments.glkote:
@@ -305,6 +317,7 @@ def main(argv: Sequence[str] | None = None) -> int:
             resources=arguments.resources,
             pixels=arguments.pixels,
             zoom=arguments.zoom or None,
+            theme=arguments.theme,
             trace=arguments.trace,
         )
     )
@@ -964,6 +977,7 @@ def _recorded_session(arguments: argparse.Namespace, identity: Identity | None) 
         resources=arguments.resources,
         pixels=arguments.pixels,
         zoom=arguments.zoom or None,
+        theme=arguments.theme,
         recorder=recorder,
         trace=arguments.trace,
     )
@@ -1303,6 +1317,7 @@ def _graphics_frontend(  # noqa: PLR0913 -- one seat per optional collaborator
     *,
     title: str | None = None,
     driven: bool = False,
+    theme: str = DEFAULT_THEME,
 ) -> "GraphicsFrontend | None":
     """A pygame window, when the graphics extra allows.
 
@@ -1337,6 +1352,7 @@ def _graphics_frontend(  # noqa: PLR0913 -- one seat per optional collaborator
             zoom=zoom,
             title=title,
             driven=driven,
+            theme=theme,
         )
     except ImportError:
         print(
@@ -2155,6 +2171,7 @@ def _play(  # noqa: PLR0911, PLR0912, PLR0913, PLR0915 -- one knob per session s
     resources: Path | None = None,
     pixels: bool = False,
     zoom: float | None = None,
+    theme: str = DEFAULT_THEME,
     recorder: Recorder | None = None,
     trace: Path | None = None,
     click_source: Callable[[], tuple[int, int] | None] | None = None,
@@ -2231,7 +2248,7 @@ def _play(  # noqa: PLR0911, PLR0912, PLR0913, PLR0915 -- one knob per session s
 
     if frontend is None and graphics:
         painted = _graphics_frontend(
-            header.version, blorb, zoom, story_path, title=caption
+            header.version, blorb, zoom, story_path, title=caption, theme=theme
         )
 
     if frontend is None and painted is None and screen:

--- a/src/voxam/glass.py
+++ b/src/voxam/glass.py
@@ -75,12 +75,36 @@ Appearance = tuple[
     str, tuple[tuple[int, int, int], tuple[int, int, int], bool, bool, bool]
 ]
 
-# The §8.3.1 colour codes as RGB, code 1 being the interpreter's
-# default ink and paper: white on black, the machine's home look.
-# The greys at 10-12 are the Version 6 additions, their values
-# scaled from the spec's own true-colour equivalents.
-INK_DEFAULT = (255, 255, 255)
-PAPER_DEFAULT = (0, 0, 0)
+# The default ink and paper the pixel glass wears -- what §8.3.1's
+# codes 0 and 1 resolve to, and (through the theme) the pair a game
+# asking for plain white on black is given. Four dressings: "dark"
+# is the home look, gentle where pure white on black glares;
+# "classic" keeps the old pure values for anyone who wants them.
+GLASS_THEMES: dict[str, tuple[tuple[int, int, int], tuple[int, int, int]]] = {
+    "dark": ((214, 214, 214), (28, 28, 28)),
+    "paper": ((0, 0, 0), (255, 255, 255)),
+    "sepia": ((67, 56, 42), (244, 236, 216)),
+    "classic": ((255, 255, 255), (0, 0, 0)),
+}
+DEFAULT_THEME = "dark"
+
+# The default ink and paper as bare names, for the Glulx GLK glass
+# next door, which imports them for its own default text and wears
+# the same home look -- though --theme does not reach it yet.
+INK_DEFAULT, PAPER_DEFAULT = GLASS_THEMES[DEFAULT_THEME]
+
+# §8.3.1's "white" (9) and "black" (2): on a real glass these are
+# the interpreter's own approximation (§8.3.3), so a game resetting
+# to them wears the theme's ink and paper rather than snapping to
+# values a themed screen never otherwise shows. The greys at 10-12
+# keep the spec's own true-colour equivalents, scaled.
+WHITE_CODE = 9
+BLACK_CODE = 2
+
+# The frame around what the screen never owns: letterbox bars
+# behind a full-window picture, the arc band's reserved region.
+# Black whatever the theme -- the universal "this is a border".
+LETTERBOX = (0, 0, 0)
 
 # The present's own cadence: a burst of writes -- Zugzwang redrawing
 # its chessboard is nearly a thousand, each once buying its own flip
@@ -450,6 +474,7 @@ class GraphicsFrontend:
         zoom: float | None = None,
         title: str | None = None,
         driven: bool = False,
+        theme: str = DEFAULT_THEME,
     ) -> None:
         """Wrap a window around a fresh screen model.
 
@@ -485,6 +510,9 @@ class GraphicsFrontend:
                 a player. A driven glass never pauses at [MORE] --
                 there is nobody to press a key, and the replay's
                 own pacing is the walk itself.
+            theme: The window's default ink and paper, one of
+                GLASS_THEMES. "dark" is the home look; "classic"
+                keeps the old pure white on black.
         """
 
         if glass is None:
@@ -562,10 +590,18 @@ class GraphicsFrontend:
         self._caret: tuple[int, int] | None = None
         self._typing = False
         self._prompt = ""
+        # The chosen dressing: the ink and paper §8.3.1's codes 0
+        # and 1 resolve to, and the fallback for any code the book
+        # does not hold.
+        self._ink, self._paper = GLASS_THEMES[theme]
         # The frontend's colour book: the §8.3.1 codes, joined by
         # a dynamic code (16 and up, §8.3.5.2) for every colour
-        # ever sampled off the glass by colour -1.
+        # ever sampled off the glass by colour -1. Codes 9 and 2
+        # follow the theme, so a game's reset to white on black
+        # wears the same dress the untouched default does (§8.3.3).
         self._colours: dict[int, tuple[int, int, int]] = dict(COLOUR_VALUES)
+        self._colours[WHITE_CODE] = self._ink
+        self._colours[BLACK_CODE] = self._paper
         self._sampled: dict[tuple[int, int, int], int] = {}
         # The presentation ledger: when the glass last flipped, and
         # whether painted rows still await a flip of their own.
@@ -716,8 +752,8 @@ class GraphicsFrontend:
         """
 
         stage = cast("StageModel", self._stage)
-        ink = self._colours.get(foreground, INK_DEFAULT)
-        paper = self._colours.get(background, PAPER_DEFAULT)
+        ink = self._colours.get(foreground, self._ink)
+        paper = self._colours.get(background, self._paper)
 
         self._repaint()
         self._glass.text(
@@ -762,7 +798,7 @@ class GraphicsFrontend:
                         italic,
                         graphics,
                     ),
-                ) = _appearance(covered, self._colours)
+                ) = _appearance(covered, self._colours, self._ink, self._paper)
 
                 self._glass.text(
                     line,
@@ -1023,7 +1059,7 @@ class GraphicsFrontend:
             return
 
         height, width = size
-        paper = self._colours.get(self._model.background, PAPER_DEFAULT)
+        paper = self._colours.get(self._model.background, self._paper)
 
         self._glass.draw(((paper,),), line, column, (width, height))
 
@@ -1222,7 +1258,7 @@ class GraphicsFrontend:
                 1,
                 self.screen_lines * self.font_height,
                 self.screen_columns * self.font_width,
-                PAPER_DEFAULT,
+                self._paper,
             )
             self._present_now()
 
@@ -1378,7 +1414,7 @@ class GraphicsFrontend:
         column = min(column, model.columns)
 
         _character, (ink, _paper, _bold, _italic, _graphics) = _appearance(
-            model.cell(row, column), self._colours
+            model.cell(row, column), self._colours, self._ink, self._paper
         )
 
         self._glass.fill(
@@ -1422,7 +1458,7 @@ class GraphicsFrontend:
         row, column = model.cursor
         column = min(column, max(model.columns - len(MORE_PROMPT) + 1, 1))
         _character, (ink, paper, _bold, _italic, _graphics) = _appearance(
-            model.cell(row, column), self._colours
+            model.cell(row, column), self._colours, self._ink, self._paper
         )
 
         self._glass.paint(
@@ -1471,7 +1507,7 @@ class GraphicsFrontend:
 
         if isinstance(paint, TextPaint):
             character, (ink, paper, bold, italic, graphics) = _appearance(
-                paint.cell, self._colours
+                paint.cell, self._colours, self._ink, self._paper
             )
 
             self._glass.text(
@@ -1490,7 +1526,7 @@ class GraphicsFrontend:
                 paint.column,
                 paint.height,
                 paint.width,
-                self._colours.get(paint.background, PAPER_DEFAULT),
+                self._colours.get(paint.background, self._paper),
             )
         else:
             self._glass.shift(
@@ -1508,7 +1544,9 @@ class GraphicsFrontend:
         """
 
         cells: list[Appearance] = [
-            _appearance(self._model.cell(row, column), self._colours)
+            _appearance(
+                self._model.cell(row, column), self._colours, self._ink, self._paper
+            )
             for column in range(1, self._model.columns + 1)
         ]
         shadow = self._shadow.get(row, [None] * self._model.columns)
@@ -1548,19 +1586,23 @@ class GraphicsFrontend:
 def _appearance(
     cell: Cell,
     colours: dict[int, tuple[int, int, int]],
+    ink_default: tuple[int, int, int],
+    paper_default: tuple[int, int, int],
 ) -> tuple[str, tuple[tuple[int, int, int], tuple[int, int, int], bool, bool, bool]]:
     """One cell's character and dress, reverse video pre-swapped.
 
-    Cells in the §16 character graphics font keep their raw
-    character and mark the dress graphics: the glass draws the
-    spec's own bitmaps for them, so no Unicode stand-in is asked
-    to approximate a pixel, and the reverse twins at 123 to 126
-    arrive as the inverted bitmaps the spec drew for them.
+    Codes the book does not hold -- 0 and 1 above all -- resolve to
+    the theme's own ink and paper. Cells in the §16 character
+    graphics font keep their raw character and mark the dress
+    graphics: the glass draws the spec's own bitmaps for them, so
+    no Unicode stand-in is asked to approximate a pixel, and the
+    reverse twins at 123 to 126 arrive as the inverted bitmaps the
+    spec drew for them.
     """
 
     style = cell.style
-    ink = colours.get(cell.foreground, INK_DEFAULT)
-    paper = colours.get(cell.background, PAPER_DEFAULT)
+    ink = colours.get(cell.foreground, ink_default)
+    paper = colours.get(cell.background, paper_default)
 
     if style & REVERSE:
         ink, paper = paper, ink
@@ -1971,7 +2013,7 @@ class _PygameGlass:
         scale = max(1, min(bounds[0] // width, bounds[1] // height))
         scaled = module.transform.scale(surface, (width * scale, height * scale))
 
-        screen.fill(PAPER_DEFAULT)
+        screen.fill(LETTERBOX)
         screen.blit(
             scaled,
             (

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -16,6 +16,8 @@ from assertpy import assert_that
 from voxam.acceptance import Recorder
 from voxam.blorb import Blorb, Resource
 from voxam.cli import (
+    DEFAULT_THEME,
+    THEME_CHOICES,
     _entitle_terminal,
     _gallery,
     _glass_frontend,
@@ -32,6 +34,8 @@ from voxam.cli import (
 )
 from voxam.frontend import PlainFrontend
 from voxam.gallery import Gallery, Resolution
+from voxam.glass import DEFAULT_THEME as GLASS_DEFAULT_THEME
+from voxam.glass import GLASS_THEMES, GraphicsFrontend
 from voxam.glass import Glass as PygameGlass
 from voxam.glulx.glk.glass import GlassFrontend as GlulxGlassFrontend
 from voxam.glulx.glk.objects import KeyCode as GlkKeyCode
@@ -2466,6 +2470,37 @@ def test_graphics_play_runs_through_the_window(
 def test_zoom_takes_a_fraction(capsys: pytest.CaptureFixture[str]) -> None:
     assert_that(main(["--zoom", "1.5", "story.z6"])).is_equal_to(2)
     assert_that(capsys.readouterr().out).contains("fraction of the desktop")
+
+
+# --theme rides through _graphics_frontend to the window's paper;
+# without it the gentle dark stands.
+def test_theme_flag_reaches_the_graphics_window(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "voxam.glass.open_pygame_glass",
+        lambda _standard=None, _version=0, _zoom=None: WindowStub(""),
+    )
+
+    default = _graphics_frontend(5, None)
+    sepia = _graphics_frontend(5, None, theme="sepia")
+
+    assert_that(cast(GraphicsFrontend, default)._paper).is_equal_to((28, 28, 28))
+    assert_that(cast(GraphicsFrontend, sepia)._paper).is_equal_to((244, 236, 216))
+
+
+# An unknown theme is refused at the parser, before a window opens.
+def test_an_unknown_theme_is_refused(capsys: pytest.CaptureFixture[str]) -> None:
+    with pytest.raises(SystemExit):
+        main(["--theme", "neon", "story.z5"])
+
+    assert_that(capsys.readouterr().err).contains("--theme")
+
+
+# The parser's theme list and the glass's own must not drift.
+def test_the_theme_choices_match_the_glass() -> None:
+    assert_that(set(THEME_CHOICES)).is_equal_to(set(GLASS_THEMES))
+    assert_that(DEFAULT_THEME).is_equal_to(GLASS_DEFAULT_THEME)
 
 
 # Without the pygame extra, the explicit flag earns a note and the

--- a/tests/test_glass.py
+++ b/tests/test_glass.py
@@ -164,11 +164,16 @@ class MeddlingGlass(StubGlass):
 
 
 def windowed(
-    version: int = 5, keys: list[str | None] | None = None
+    version: int = 5,
+    keys: list[str | None] | None = None,
+    theme: str = "classic",
 ) -> tuple[GraphicsFrontend, StubGlass]:
+    # The mechanics tests pin "classic" so ink and paper stay the
+    # plain WHITE and BLACK they assert; the default theme and the
+    # rest have their own tests below.
     glass = StubGlass(keys)
 
-    return GraphicsFrontend(version, glass=glass), glass
+    return GraphicsFrontend(version, glass=glass, theme=theme), glass
 
 
 def runs_containing(glass: StubGlass, text: str) -> list[tuple[object, ...]]:
@@ -448,6 +453,73 @@ def test_font_3_runs_keep_their_characters_and_go_graphics() -> None:
 
     assert_that(text).is_equal_to("({")
     assert_that(graphics).is_true()
+    assert_that(ink).is_equal_to(WHITE)
+    assert_that(paper).is_equal_to(BLACK)
+
+
+# The home look is the gentle dark: an untouched glass sets its
+# text in soft grey on charcoal, not the pure white on black that
+# glares (#319).
+def test_the_default_theme_softens_the_glass() -> None:
+    glass = StubGlass()
+    frontend = GraphicsFrontend(5, glass=glass)
+
+    frontend.write("plain")
+
+    (_, _, _, ink, paper, _, _, _) = runs_containing(glass, "plain")[0]
+
+    assert_that(ink).is_equal_to((214, 214, 214))
+    assert_that(paper).is_equal_to((28, 28, 28))
+
+
+# Each theme is a whole dressing of the default ink and paper.
+def test_a_theme_dresses_the_default_ink_and_paper() -> None:
+    glass = StubGlass()
+    frontend = GraphicsFrontend(5, glass=glass, theme="sepia")
+
+    frontend.write("aged")
+
+    (_, _, _, ink, paper, _, _, _) = runs_containing(glass, "aged")[0]
+
+    assert_that(ink).is_equal_to((67, 56, 42))
+    assert_that(paper).is_equal_to((244, 236, 216))
+
+
+# Codes 9 and 2 -- "white" and "black" -- follow the theme, so a
+# game resetting to them looks no harsher than one that left the
+# colours alone; the other six stay their true values (§8.3.3).
+def test_white_and_black_follow_the_theme() -> None:
+    glass = StubGlass()
+    frontend = GraphicsFrontend(5, glass=glass, theme="dark")
+
+    frontend.set_colour(9, 2)
+    frontend.write("reset")
+
+    (_, _, _, ink, paper, _, _, _) = runs_containing(glass, "reset")[0]
+
+    assert_that(ink).is_equal_to((214, 214, 214))
+    assert_that(paper).is_equal_to((28, 28, 28))
+
+    frontend.set_colour(3, 4)
+    frontend.write("leaf")
+
+    (_, _, _, ink, paper, _, _, _) = runs_containing(glass, "leaf")[0]
+
+    assert_that(ink).is_equal_to((204, 0, 0))
+    assert_that(paper).is_equal_to((0, 204, 0))
+
+
+# The "classic" theme is the old look kept whole: pure white on
+# black, codes 9 and 2 included.
+def test_classic_keeps_pure_white_on_black() -> None:
+    glass = StubGlass()
+    frontend = GraphicsFrontend(5, glass=glass, theme="classic")
+
+    frontend.set_colour(9, 2)
+    frontend.write("pure")
+
+    (_, _, _, ink, paper, _, _, _) = runs_containing(glass, "pure")[0]
+
     assert_that(ink).is_equal_to(WHITE)
     assert_that(paper).is_equal_to(BLACK)
 


### PR DESCRIPTION
Closes #319.

## The problem

The pygame (pixel glass) frontend rendered default text as pure `(255, 255, 255)` on pure `(0, 0, 0)` — the single harshest ink/paper pair, which halates on an emissive display. Every other face (desktop, browser) is gentler and themeable; the glass was the odd one out.

## What changed

**1. Softened default.** `GLASS_THEMES` — four dressings — with `dark` the default: `(214, 214, 214)` on `(28, 28, 28)`, matching the desktop's own dark theme (`#d6d6d6` / `#1c1c1c`). The Glulx GLK glass imports `INK_DEFAULT` / `PAPER_DEFAULT` from this module, so it inherits the gentler default for free.

**2. White and black follow the theme.** On the pixel glass, §8.3.1 codes 9 and 2 resolve through the theme's ink and paper — §8.3.3 already lets the interpreter approximate the eight colours, so a game's `set_colour(9, 2)` "reset to plain" looks no harsher than the untouched default. Codes 3–8 and the greys 10–12 stay exact. Letterbox bars behind full-window cover art stay black (`LETTERBOX`) whatever the theme.

**3. `--theme {classic,dark,paper,sepia}`.** Threaded through `_play` and `_recorded_session` → `_graphics_frontend` → `GraphicsFrontend`, so it works for interactive play and `--record`. `classic` keeps the old pure white on black. The parser's choice list is kept locked to `GLASS_THEMES` by a drift test.

## Deferred (not here)

`--theme` does not reach the Glulx GLK glass (`glulx/glk/glass.py`) or the filmstrip/replay paths yet — Glulx games get the softened default but not the flag.

## Verification

`2043 passed`, 100% coverage, `mypy --strict` clean, `ruff` clean. zork1 regtest and CZECH z5 smoke pass. The `windowed()` test helper is pinned to `classic` so the mechanics tests keep asserting pure values; 8 new tests cover the default, each theme, the 9/2 remap, `classic` fidelity, flag propagation, and the drift guard.