### PR TITLE
fix(screen): the wire's screen model follows the display's font size

### DIFF
--- a/src/voxam/screen.py
+++ b/src/voxam/screen.py
@@ -111,6 +111,13 @@ class ScreenModel:
         self._pending: list[Cell] = []
         self._scroll_due = False
         self._damage: set[int] = set()
+        # The last §8.2 status line drawn, kept so a resize can
+        # redraw it at the new width. Before Version 4 the line is
+        # the interpreter's own, redrawn at each read, so a screen
+        # that changes size between reads would otherwise sit with
+        # the score stranded at the old column until the player
+        # typed something. Version 4 on never draws one here.
+        self._status: Status | None = None
         # [MORE] paging is interpreter courtesy: a frontend that
         # wants a pause before a screenful of unread text scrolls
         # away hangs a callback here, and the model counts the
@@ -378,8 +385,11 @@ class ScreenModel:
         and the upper window stay where they were; the fresh margin
         blanks in the current background. The split and both cursors
         are drawn back inside the new bounds, and every row is left
-        damaged so the painter redraws the whole screen. A size that
-        did not actually change does nothing.
+        damaged so the painter redraws the whole screen. A §8.2
+        status line already standing is drawn again at the new
+        width, since the interpreter owns that row and would not
+        otherwise touch it until the next read. A size that did not
+        actually change does nothing.
         """
 
         columns = max(1, columns)
@@ -421,6 +431,9 @@ class ScreenModel:
         self._scroll_due = False
         self._fed = 0
         self._damage = set(range(1, lines + 1))
+
+        if self._status is not None:
+            self.show_status(self._status)
 
     def split_window(self, height: int) -> None:
         """Resize the upper window to the given height (§8.7.2.1).
@@ -806,6 +819,7 @@ class ScreenModel:
             Cell(character, REVERSE) for character in line[: self._columns]
         ]
         self._damage.add(1)
+        self._status = status
 
     def sweep(self) -> list[int]:
         """The rows changed since the last sweep, in screen order.

--- a/src/voxam/zmachine/glkote.py
+++ b/src/voxam/zmachine/glkote.py
@@ -39,7 +39,7 @@ is refused loudly at the door.
 
 import json
 from base64 import b64encode
-from collections.abc import Mapping, Sequence
+from collections.abc import Callable, Mapping, Sequence
 from typing import Final, TextIO
 
 from voxam.babel import ifiction
@@ -210,6 +210,12 @@ class GlkOteFrontend(PlainFrontend):
         self._runs: list[tuple[str, int, str] | object] = []
         self._cleared = False
         self._style = 0
+        # An arrange re-measures the display mid-session -- the
+        # shell's Display menu changing the font size is one, with
+        # the same box holding fewer or more cells -- and the model
+        # follows it. Set by the machine, which re-stamps the §8.4
+        # header fields through it; None leaves the header be.
+        self.on_resize: Callable[[], None] | None = None
         self._size = (0, 0)
         self._cell = (1.0, 1.0)
         self._margins = (0.0, 0.0)
@@ -993,10 +999,16 @@ class GlkOteFrontend(PlainFrontend):
     def _reshaped(self, kind: str, stanza: Stanza) -> str:
         """An arrange or redraw: the picture re-shapes or re-paints.
 
-        An arrange re-measures -- the next reload boots a machine
-        at the new size (§8.4), while a hanging band re-shapes now
-        and its rows-below claim follows. A redraw re-feeds the
-        band whole (GlkOte: Redraw Events); without one there is
+        An arrange re-measures, and the screen model follows it to
+        the new size: the display's own font size can move mid-
+        session, and a model left at the size it booted against
+        composes the §8.2 status line for a screen that is no
+        longer there -- the score stranded off the right edge of a
+        narrowed grid, and a widened one reaching past the row it
+        has. The §8.4 header fields follow too, through the
+        machine's own callback. A hanging band re-shapes now and
+        its rows-below claim follows. A redraw re-feeds the band
+        whole (GlkOte: Redraw Events); without one there is
         nothing here to redraw.
         """
 
@@ -1009,6 +1021,10 @@ class GlkOteFrontend(PlainFrontend):
             return STAND
 
         self._measure(stanza)
+        self._model.resize(self.screen_columns, self.screen_lines)
+
+        if self.on_resize is not None:
+            self.on_resize()
 
         if self._band is not None:
             self._band_dirty = True

--- a/src/voxam/zmachine/header.py
+++ b/src/voxam/zmachine/header.py
@@ -115,6 +115,14 @@ SCREEN_COLUMNS = 0x21
 SCREEN_FIELDS_VERSION = 4
 INFINITE_LINES = 255
 
+# What the size fields themselves can hold. A display measuring
+# itself in cells one unit wide -- the fallback when its metrics
+# name no character size (GlkOte: The Metrics Object) -- offers
+# more columns than a byte has room for, so the claim is capped at
+# the field's own ceiling rather than overflowing it.
+BYTE_CEILING = 255
+WORD_CEILING = 0xFFFF
+
 # Field locations from the table in §11.1.
 RELEASE = 0x02
 HIGH_MEMORY_BASE = 0x04
@@ -509,7 +517,10 @@ class Header:
         """Record the screen size in lines and characters (§8.4).
 
         255 lines means "infinite": the claim of a stream that never
-        pages.
+        pages. Both fields are single bytes, so a screen larger than
+        either can hold is claimed at 255, the most the byte can
+        honestly say -- a display measuring itself in cells one unit
+        wide can offer more columns than the field has room for.
 
         Raises:
             ZMachineHeaderError: Before Version 4, where the fields
@@ -519,8 +530,8 @@ class Header:
         self._require_screen_fields()
 
         live = self._live()
-        live[SCREEN_LINES] = lines
-        live[SCREEN_COLUMNS] = columns
+        live[SCREEN_LINES] = min(lines, BYTE_CEILING)
+        live[SCREEN_COLUMNS] = min(columns, BYTE_CEILING)
 
     def declare_presentation(
         self, *, bold: bool, italic: bool, fixed_pitch: bool, timed_input: bool
@@ -705,9 +716,14 @@ class Header:
 
             raise ZMachineHeaderError(msg)
 
+        # Word fields, capped the way the byte fields above are.
         live = self._live()
-        live[SCREEN_WIDTH_UNITS : SCREEN_WIDTH_UNITS + 2] = width.to_bytes(2, "big")
-        live[SCREEN_HEIGHT_UNITS : SCREEN_HEIGHT_UNITS + 2] = height.to_bytes(2, "big")
+        live[SCREEN_WIDTH_UNITS : SCREEN_WIDTH_UNITS + 2] = min(
+            width, WORD_CEILING
+        ).to_bytes(2, "big")
+        live[SCREEN_HEIGHT_UNITS : SCREEN_HEIGHT_UNITS + 2] = min(
+            height, WORD_CEILING
+        ).to_bytes(2, "big")
 
     def declare_colours(
         self, *, available: bool, foreground: int, background: int

--- a/tests/test_screen_model.py
+++ b/tests/test_screen_model.py
@@ -827,3 +827,27 @@ def test_resize_floors_at_one_by_one() -> None:
 
     assert_that(screen.columns).is_equal_to(1)
     assert_that(screen.lines).is_equal_to(1)
+
+
+# The §8.2 status line is the interpreter's own row, drawn afresh at
+# each read -- so a screen resized between reads would otherwise sit
+# with its score stranded at the column the old width put it in. A
+# resize draws the standing line again, fitted to the new width.
+def test_a_resize_redraws_the_standing_status_line() -> None:
+    model = ScreenModel(columns=40, lines=HEIGHT, version=3)
+
+    model.show_status(Status("West of House", 0, 1, time_game=False))
+
+    assert_that(model.row_text(1)).ends_with("Score: 0  Moves: 1")
+
+    # Narrow enough that §8.2.2.2's ellipsis rule applies again,
+    # which it could not do from the row as it already stood.
+    model.resize(30, HEIGHT)
+
+    assert_that(model.row_text(1)).starts_with(" West o...")
+    assert_that(model.row_text(1)).ends_with("Score: 0  Moves: 1")
+
+    model.resize(60, HEIGHT)
+
+    assert_that(model.row_text(1)).is_length(59)
+    assert_that(model.row_text(1)).ends_with("Score: 0  Moves: 1")

--- a/tests/zmachine/test_glkote.py
+++ b/tests/zmachine/test_glkote.py
@@ -30,20 +30,22 @@ from voxam.zmachine.glkote import (
     fronted,
     serve,
 )
-from voxam.zmachine.header import SCREEN_LINES
+from voxam.zmachine.header import SCREEN_COLUMNS, SCREEN_LINES
 from voxam.zmachine.machine import Machine
 from voxam.zmachine.story import Story
+
+METRICS: dict[str, Any] = {
+    "width": 800,
+    "height": 480,
+    "gridcharwidth": 10,
+    "gridcharheight": 20,
+}
 
 INIT = {
     "type": "init",
     "gen": 0,
     "support": ["timer"],
-    "metrics": {
-        "width": 800,
-        "height": 480,
-        "gridcharwidth": 10,
-        "gridcharheight": 20,
-    },
+    "metrics": METRICS,
 }
 
 TEXT_BUFFER = 0x120
@@ -2105,3 +2107,88 @@ def test_the_stage_speaks_the_sidecar_too() -> None:
 
     assert_that(block["score"]).is_zero()
     assert_that(block["discontinuity"]).is_true()
+
+
+def arranged(frontend: GlkOteFrontend, cell_width: int) -> dict[str, Any]:
+    """An arrange in the same box, its grid cells a new width."""
+
+    return {
+        "type": "arrange",
+        "gen": frontend.page.gen,
+        "metrics": {**METRICS, "gridcharwidth": cell_width},
+    }
+
+
+def status_row(frontend: GlkOteFrontend) -> str:
+    """The grid's first row, one render's worth."""
+
+    lines = frontend.render()["content"][-1]["lines"]
+
+    return "".join(run["text"] for run in lines[0]["content"])
+
+
+# Issue #322: a display can change its own font size mid-session --
+# the desktop shell's Display menu does exactly that, live -- so an
+# arrange re-measures the grid and the screen model follows it. Left
+# at the size it booted against, the model composes the §8.2 status
+# line for a screen that is no longer there: on a narrowed grid the
+# score is stranded off the right edge, and a widened one reaches
+# for cells the model's rows do not have.
+def test_an_arrange_resizes_the_screen_model(
+    code_machine: Callable[..., Machine],
+) -> None:
+    frontend, _ = opened(code_machine, version=3)
+
+    frontend.show_status(Status("West of House", 0, 1, time_game=False))
+
+    booted = status_row(frontend)
+
+    assert_that(booted).is_length(80)
+    assert_that(booted).ends_with("Score: 0  Moves: 1 ")
+
+    # A bigger font: the same box, holding fewer cells.
+    frontend.accept(arranged(frontend, 13))
+
+    narrowed = status_row(frontend)
+
+    assert_that(frontend.screen_columns).is_equal_to(61)
+    assert_that(narrowed).is_length(61)
+    assert_that(narrowed).starts_with(" West of House")
+    assert_that(narrowed).ends_with("Score: 0  Moves: 1 ")
+
+    # And a smaller one, which used to reach past the row.
+    frontend.accept(arranged(frontend, 8))
+
+    widened = status_row(frontend)
+
+    assert_that(frontend.screen_columns).is_equal_to(100)
+    assert_that(widened).is_length(100)
+    assert_that(widened).ends_with("Score: 0  Moves: 1 ")
+
+
+# The §8.4 screen fields follow the same arrange, through the
+# callback the machine hangs on the frontend at boot: a Version 5
+# story asking how wide its screen is gets the size the display
+# just gave, not the one it booted against.
+def test_an_arrange_restamps_the_screen_header(
+    code_machine: Callable[..., Machine],
+) -> None:
+    frontend, machine = opened(code_machine, version=5)
+
+    assert_that(machine.memory.read_byte(SCREEN_COLUMNS)).is_equal_to(80)
+
+    frontend.accept(arranged(frontend, 13))
+
+    assert_that(machine.memory.read_byte(SCREEN_COLUMNS)).is_equal_to(61)
+    assert_that(machine.memory.read_byte(SCREEN_LINES)).is_equal_to(24)
+
+
+# An arrange arriving before any machine stands behind the display
+# still reshapes the model; there is simply no header to re-stamp.
+def test_an_arrange_with_no_machine_reshapes_all_the_same() -> None:
+    bare = GlkOteFrontend(3)
+
+    bare.begin(INIT)
+
+    assert_that(bare.accept(arranged(bare, 13))).is_equal_to(STAND)
+    assert_that(bare.screen_columns).is_equal_to(61)

--- a/tests/zmachine/test_header.py
+++ b/tests/zmachine/test_header.py
@@ -516,3 +516,20 @@ def test_mouse_and_menu_requests_clear_when_refused() -> None:
     header.declare_menus(available=False)
 
     assert_that(int.from_bytes(header.data[0x10:0x12], "big")).is_zero()
+
+
+# The §8.4 size fields are a byte each, and the §8.4.3 unit fields a
+# word each, so a screen larger than a field can hold is claimed at
+# that field's ceiling rather than overflowing it. A display whose
+# metrics name no character size measures itself in cells one unit
+# wide (GlkOte: The Metrics Object) and offers exactly that.
+def test_a_screen_past_the_fields_is_claimed_at_their_ceiling() -> None:
+    header = Header(bytearray(synthetic_header(version=5)))
+
+    header.declare_screen_size(lines=400, columns=1000)
+    header.declare_screen_units(width=100_000, height=90_000)
+
+    assert_that(header.data[0x20]).is_equal_to(255)
+    assert_that(header.data[0x21]).is_equal_to(255)
+    assert_that(header.data[0x22:0x24]).is_equal_to(b"\xff\xff")
+    assert_that(header.data[0x24:0x26]).is_equal_to(b"\xff\xff")


### PR DESCRIPTION
## What this changes

Closes #322. Reported by @robbsherwin: *Hollywood Hijinx* at Display >
Size > 18 in the desktop shell pushed the status line's score and turn
counter off the right edge, leaving only `Sc` visible.

### The cause

The Z-Machine's GlkOte face re-measures the display on an `arrange`, and
the shell's Display menu pokes a resize precisely so that one arrives when
the font size changes. But the face never passed the new size to the
`ScreenModel` behind it, so the model went on composing the §8.2 status
line for the screen it booted against. His story, at his sizes:

```
15px cells    gridwidth=131   row(131): ' South Junction ... Score: 0  Moves: 0 '
18px cells    gridwidth=107   row(131) drawn onto a 107-column grid
```

Everything past column 107 was simply clipped, and column 107 onward is
where §8.2.3 puts the score.

### The half of it that was not reported

The same gap fails harder in the other direction. A font *smaller* than
the default widens the grid, and `_faced` walks to the freshly measured
`screen_columns` while indexing a model still holding the old, shorter
rows:

```
IndexError: list index out of range
  screen.py, in cell: return self._grid[row - 1][column - 1]
```

On the wire that is a fault stanza and exit 2, so choosing a smaller font
was killing the session outright. Reproduced from the Size menu on 2.4.0
before this branch, and it is the same root cause, so it is fixed here
rather than filed separately.

Worth noting that STATUS.md has claimed since `1.9` that the Display
menu's changes are "applied live, a poked resize re-measures the metrics
and the machines take the new arrangement as they take any other." For
the Z-Machine grid that claim was not true. This makes the ledger honest
rather than needing an edit.

### The fix

- **`zmachine/glkote.py`** — `_reshaped` now resizes the screen model to
  the newly measured size and fires the machine's `on_resize`, so the
  §8.4 header fields follow too from Version 4 on. That callback seam is
  #318's, used as it stands.
- **`screen.py`** — the model remembers the last §8.2 status line and
  redraws it after a resize. Without this the row would be honestly sized
  but stale until the player's next command, because before Version 4 the
  status line is the interpreter's own row and it is only drawn at a read.
  The redraw also re-applies §8.2.2.2's ellipsis rule, which the standing
  row could not do for itself. This lands in the shared model, so the
  painted terminal picks it up as well: #318 left the same staleness there.
- **`zmachine/header.py`** — the §8.4 size fields are capped at what they
  can hold. A display whose metrics name no character size measures itself
  in cells one unit wide, which is the spec's own fallback chain (GlkOte:
  The Metrics Object), and offers hundreds of columns;
  `live[SCREEN_COLUMNS] = 400` is a `ValueError`. The byte fields now cap
  at 255 and the §8.4.3 unit words at `$ffff`. That hole was latent at boot
  too, and re-stamping on every arrange is what brought it into reach.

### Verification

- Gate green: 2,049 tests, 100% branch coverage, format/lint/mypy clean.
- Five new tests: the model follows an arrange in both directions with the
  status line refitted, the header re-stamps through the wire, an arrange
  with no machine behind it still reshapes, the model redraws a standing
  status line at a new width, and the size fields claim their ceiling.
- Live on the real wire with *Hollywood Hijinx* r37 s861215 on the reported
  route (boot, font up, font down, then a command): the status line refits
  at every size and the session exits 0. Confirmed by hand in the Tauri
  shell too.
- Corpus sweep: all 44 recordings replayed, 105 warnings, no change. Two
  tallies differ from the baseline recorded at `1.8.0` (curses 7 not 8,
  mulldoon 1 not 2); both were verified pre-existing by replaying against
  HEAD's own `src/voxam`, and neither could move here, since a replay runs
  the plain frontend, which never arranges and never resizes.

## Checklist

- [x] **The gate passes locally**
- [x] **The PR title is a conventional commit**
- [x] **Spec citations accompany behavior changes** (§8.2, §8.2.2.2,
      §8.4, §8.4.3, and GlkOte's Metrics Object for the fallback chain)
- [x] **The corpus still replays** (see above)
- [x] **`entharion/` is untouched**
