### PR TITLE
fix(rng): a seeded session keeps its seed through a reseed to entropy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,29 +125,23 @@ jobs:
       # verdict spoken -- through the same stdio session a player
       # would use.
       #
-      # --seed 777 pins every section that draws on the session
-      # stream, but RandomTest reseeds from real entropy itself
-      # (`@setrandom 0`) and then checks the histogram against wide
-      # but finite bounds -- it prints its own warning that it
-      # "may, very occasionally, fail through sheer bad luck." So
-      # the battery is retried: a real regression fails every
-      # attempt, one unlucky histogram does not. True determinism
-      # for RandomTest is issue #316.
+      # --seed 777 pins the whole battery, RandomTest included.
+      # That section reseeds to entropy itself (`@setrandom 0`)
+      # and then checks its histogram against wide but finite
+      # bounds, warning in its own words that it "may, very
+      # occasionally, fail through sheer bad luck" -- which twice
+      # read as a phantom regression on a green change. Under an
+      # explicit --seed the reseed now draws off the seeded stream
+      # instead (#316), so the run is byte-identical every time and
+      # the retry loop that stood here is no longer earning its
+      # keep.
       - name: Glulxercise, the whole battery
         run: |
-          for attempt in 1 2 3; do
-            out="$(echo all | uv run voxam --seed 777 entharion/glulx-checkers/glulxercise-r13-s241202.ulx)"
-            if [ "$(echo "$out" | grep -c '^Passed\.$')" -eq 70 ] \
-              && echo "$out" | grep -q "All tests passed." \
-              && ! echo "$out" | grep -q "FAILED"; then
-              echo "$out" | tail -3
-              exit 0
-            fi
-            echo "::warning::glulxercise attempt $attempt did not certify"
-            echo "$out" | tail -5
-          done
-          echo "::error::glulxercise did not certify in 3 attempts"
-          exit 1
+          out="$(echo all | uv run voxam --seed 777 entharion/glulx-checkers/glulxercise-r13-s241202.ulx)"
+          echo "$out" | tail -3
+          test "$(echo "$out" | grep -c '^Passed\.$')" -eq 70
+          echo "$out" | grep -q "All tests passed."
+          ! echo "$out" | grep -q "FAILED"
 
   build:
     name: Build distribution

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -41,7 +41,13 @@ exposed; it's a commitment the whole architecture serves. The
 dice are seedable in every machine (the Å-machine's are the
 reference implementation's own stream, so even cross-interpreter
 comparisons hold), and every recorded playthrough is expected to
-replay byte for byte until the end of time.
+replay byte for byte until the end of time. This is the one
+principle allowed to outrank fidelity, and it outranks it exactly
+once: a story asking to reseed itself from entropy is answered
+off the seeded stream when, and only when, the operator passed
+`--seed`. The flag already overrides that same rule at game
+start, so the alternative is not a purer reading of the
+specification but a flag that lies.
 
 **Certification over promise.** Claims are enforced in continuous
 integration or they are not made. The community's own checkers

--- a/README.md
+++ b/README.md
@@ -327,6 +327,18 @@ same commands produce the same session, every time.
 voxam --seed 1137 path/to/story.z3
 ```
 
+That promise holds even when the story reseeds itself. A game may
+ask for genuine unpredictability mid-session (`random 0` in the
+Z-Machine, `@setrandom 0` in Glulx), and in an ordinary session it
+gets exactly that, from the operating system's own entropy. Under
+an explicit `--seed`, the new dice are drawn off the seeded stream
+instead, so the whole run stays a function of the one seed given.
+It is the only place Voxam knowingly answers a story with
+something other than what the specification asks for, and it is
+narrow on purpose: `--seed` already overrides the same rule at
+game start, a session without the flag is untouched, and without
+it the flag would make a promise the interpreter quietly broke.
+
 Blorb resources ride along automatically: a `.zblorb` story boots
 from its package, and a like-named `.blb` beside a story file is
 found on its own and, if the names differ, then `--resources` names

--- a/src/voxam/glulx/rng.py
+++ b/src/voxam/glulx/rng.py
@@ -61,6 +61,10 @@ class Randomizer:
                 None means true entropy.
         """
 
+        # Whether the operator asked for a reproducible session,
+        # which is what decides where a later reseed-to-entropy
+        # draws its state from. See seed().
+        self._seeded = seed is not None
         self._state = _entropy() if seed is None else _mixed(seed)
 
     def word(self) -> int:
@@ -88,7 +92,26 @@ class Randomizer:
         """Reseed the stream -- setrandom's work.
 
         A seed of zero asks for genuine unpredictability (Glulx:
-        The Random Number Generator).
+        The Random Number Generator), and gets it in an ordinary
+        session.
+
+        In a session the operator seeded, it draws its new state off
+        the seeded stream instead. This is a deliberate deviation,
+        and a narrow one: `--seed` already overrides the same rule at
+        game start, where the generator is likewise meant to be
+        unpredictable, so honoring the flag here only makes it mean
+        at turn five hundred what it meant at turn one. Without it a
+        story that reseeds silently breaks the flag's whole promise,
+        and no recording that reaches such a story could ever replay.
+        A session given no seed reaches the entropy below, as always.
         """
 
-        self._state = _entropy() if value == 0 else _mixed(value)
+        if value != 0:
+            self._state = _mixed(value)
+        elif self._seeded:
+            # Off the stream itself: no counter to keep, successive
+            # reseeds still differ, and the whole run stays a
+            # function of the one seed the operator gave.
+            self._state = _mixed(self.word())
+        else:
+            self._state = _entropy()

--- a/src/voxam/zmachine/rng.py
+++ b/src/voxam/zmachine/rng.py
@@ -70,6 +70,10 @@ class Randomizer:
                 entropy.
         """
 
+        # Whether the operator asked for a reproducible session,
+        # which is what decides where a later return to the random
+        # state draws from. See randomize().
+        self._seeded = seed is not None
         self._state = _entropy() if seed is None else _mixed(seed)
         self._sequence_limit: int | None = None
         self._sequence_at = 0
@@ -112,11 +116,26 @@ class Randomizer:
         """Return to the random state, seeded as randomly as possible.
 
         The random opcode with a range of 0 asks for exactly this
-        (§15 random).
+        (§15 random), and gets it in an ordinary session.
+
+        In a session the operator seeded, the new state comes off the
+        seeded stream instead. This is a deliberate deviation, and a
+        narrow one: §2.4 puts the generator in the random state at
+        game start too, which `--seed` already overrides, so honoring
+        the flag here only makes it mean at turn five hundred what it
+        meant at turn one. Without it a story that reseeds silently
+        breaks the flag's whole promise, and no recording that
+        reaches such a story could ever replay. A session given no
+        seed reaches the entropy below, as always.
         """
 
         self._sequence_limit = None
-        self._state = _entropy()
+        # Off the stream itself: no counter to keep, successive
+        # returns still differ, and the whole run stays a function of
+        # the one seed the operator gave. _next() advances the
+        # xorshift even from the rising sequence, whose own counter
+        # never touched it.
+        self._state = _mixed(self._next()) if self._seeded else _entropy()
 
     def _next(self) -> int:
         """Advance the xorshift32 stream one step."""

--- a/tests/glulx/test_rng.py
+++ b/tests/glulx/test_rng.py
@@ -2,6 +2,7 @@
 
 from collections.abc import Callable
 
+import pytest
 from assertpy import assert_that
 
 from voxam.glulx.machine import Machine
@@ -79,3 +80,68 @@ def test_the_random_opcode_rolls_its_three_ranges(
     rolled(seeded, bytes([0x81, 0x11, 0x21, 0x30, 0x39]))
 
     assert_that(rolled(drifted, full)).is_equal_to(rolled(seeded, full))
+
+
+# Issue #316: setrandom 0 asks for genuine unpredictability, and gets
+# it -- but in a session the operator seeded, honoring that ask would
+# break the promise --seed makes. So a seeded session reseeds off its
+# own stream: two twins that reseed together stay twins, and the whole
+# run remains a function of the one seed given.
+def test_a_seeded_session_survives_a_reseed_to_entropy() -> None:
+    first = Randomizer(7)
+    second = Randomizer(7)
+
+    first.word()
+    second.word()
+
+    first.seed(0)
+    second.seed(0)
+
+    run = [first.word() for _ in range(5)]
+
+    assert_that([second.word() for _ in range(5)]).is_equal_to(run)
+
+    # Successive reseeds still move the stream on, so a story asking
+    # twice does not get the same dice twice.
+    first.seed(0)
+
+    assert_that(first.word()).is_not_equal_to(run[0])
+
+    # And a differently seeded session is still a different session.
+    other = Randomizer(8)
+
+    other.word()
+    other.seed(0)
+
+    assert_that(other.word()).is_not_equal_to(run[0])
+
+
+# With no --seed there is nothing to keep faith with, so the zero case
+# reaches the operating system's entropy the specification asks for --
+# and a seeded session never reaches it at all.
+def test_the_entropy_path_is_the_unseeded_one(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "voxam.glulx.rng.os.urandom", lambda size: b"\x05\x06\x07\x08"[:size]
+    )
+
+    first = Randomizer()
+    second = Randomizer()
+
+    first.word()
+    first.word()
+
+    first.seed(0)
+    second.seed(0)
+
+    # Both landed on the same entropy, wherever their streams stood:
+    # a reseed off the stream could not have converged them.
+    assert_that(first.word()).is_equal_to(second.word())
+
+    def refuse(size: int) -> bytes:
+        pytest.fail(f"a seeded session asked for {size} bytes of entropy")
+
+    monkeypatch.setattr("voxam.glulx.rng.os.urandom", refuse)
+
+    Randomizer(7).seed(0)

--- a/tests/zmachine/test_rng.py
+++ b/tests/zmachine/test_rng.py
@@ -1,3 +1,4 @@
+import pytest
 from assertpy import assert_that
 
 from voxam.zmachine.rng import Randomizer
@@ -85,3 +86,79 @@ def test_randomize_leaves_the_predictable_state() -> None:
 
     for _ in range(10):
         assert_that(rng.roll(4)).is_between(1, 4)
+
+
+# Issue #316: random 0 returns to the random state, "seeded as randomly
+# as possible" (§2.4), and does -- but in a session the operator seeded,
+# honoring that would break the promise --seed makes. So a seeded
+# session re-randomizes off its own stream: two twins that re-randomize
+# together stay twins, and the run remains a function of the one seed.
+def test_a_seeded_session_survives_a_return_to_the_random_state() -> None:
+    first = Randomizer(seed=1137)
+    second = Randomizer(seed=1137)
+
+    first.roll(6)
+    second.roll(6)
+
+    first.randomize()
+    second.randomize()
+
+    run = [first.roll(100) for _ in range(5)]
+
+    assert_that([second.roll(100) for _ in range(5)]).is_equal_to(run)
+
+    # The rising sequence never touches the stream, so a story that
+    # seeds low and then re-randomizes still lands somewhere fixed.
+    third = Randomizer(seed=1137)
+    fourth = Randomizer(seed=1137)
+
+    third.seed(3)
+    third.roll(10)
+    third.randomize()
+
+    fourth.seed(3)
+    fourth.roll(10)
+    fourth.randomize()
+
+    assert_that([third.roll(100) for _ in range(5)]).is_equal_to(
+        [fourth.roll(100) for _ in range(5)]
+    )
+
+    # A differently seeded session is still a different session.
+    other = Randomizer(seed=1138)
+
+    other.roll(6)
+    other.randomize()
+
+    assert_that([other.roll(100) for _ in range(5)]).is_not_equal_to(run)
+
+
+# With no --seed there is nothing to keep faith with, so random 0
+# reaches the operating system's entropy as §2.4 asks -- and a seeded
+# session never reaches it at all.
+def test_the_entropy_path_is_the_unseeded_one(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "voxam.zmachine.rng.os.urandom", lambda size: b"\x05\x06\x07\x08"[:size]
+    )
+
+    first = Randomizer()
+    second = Randomizer()
+
+    first.roll(6)
+    first.roll(6)
+
+    first.randomize()
+    second.randomize()
+
+    # Both landed on the same entropy, wherever their streams stood:
+    # a re-randomize off the stream could not have converged them.
+    assert_that(first.roll(100)).is_equal_to(second.roll(100))
+
+    def refuse(size: int) -> bytes:
+        pytest.fail(f"a seeded session asked for {size} bytes of entropy")
+
+    monkeypatch.setattr("voxam.zmachine.rng.os.urandom", refuse)
+
+    Randomizer(seed=1137).randomize()


### PR DESCRIPTION
## What this changes

Closes #316. `--seed` promised a reproducible session but did not survive
the story reseeding itself. Both engines sent an in-story reseed-to-entropy
straight to `os.urandom` no matter what the operator had asked for:
`@setrandom 0` in Glulx, `random 0` in the Z-Machine (§2.4, §15 random).

So a recorded playthrough that reached such a story could never replay, and
glulxercise's `RandomTest` section, which does exactly this and then checks
a histogram, stayed statistically flaky in CI however the seed was pinned.
That flake was worked around with a retry loop in #317.

### Before and after

`voxam --seed 777 glulxercise-r13-s241202.ulx`, three runs each, whole
transcript digested:

```
before   6445736b37d7   f129ce0965ab   a7780baefe89
after    cf23b2730e0f   cf23b2730e0f   cf23b2730e0f     70 passed, "All tests passed."
```

And with no `--seed`, three runs, after the change:

```
52bafafb88d4   98a85b59d7eb   ...
```

Determinism where it was promised, real entropy where the specification
asks and nobody asked otherwise.

### The change

Both `Randomizer` classes already take `seed: int | None`, so they already
know whether the operator asked for a reproducible session. The whole fix is
remembering that and branching on it:

- **`glulx/rng.py`** — `seed(0)` takes `_mixed(self.word())` when seeded,
  `_entropy()` otherwise.
- **`zmachine/rng.py`** — `randomize()` takes `_mixed(self._next())` when
  seeded, `_entropy()` otherwise. `_next()` advances the xorshift even out
  of the §2 remarks rising-sequence mode, whose own counter never touches
  the stream, so a story that seeds low and then re-randomizes still lands
  somewhere fixed. There is a test for that case.

The new state comes off the stream rather than from a counter mixed with
the seed, as the issue sketched. It keeps no extra state, successive reseeds
still differ so a story asking twice does not get the same dice twice, and
the whole run stays a function of the one seed given.

### On the deviation

This is a deliberate deviation, and the issue weighed honoring the specs'
"genuine unpredictability" against it. I think that case is weaker than it
looks. §2.4 puts the generator in the random state at game start too, and
`--seed` already overrides exactly that. The deviation is not new; it is
already there, already documented, and already gated behind a flag no
ordinary player passes. What this does is make it consistent, so `--seed`
means at turn five hundred what it meant at turn one. As it stood, the flag
made a promise the interpreter quietly broke.

A session given no seed is untouched and fully conformant.

Written down where the doctrine says it should be: README gains a paragraph
after the `--seed` example, and DESIGN's "Reproducibility, forever" now
names this as the one place that principle outranks fidelity, with the
argument that the alternative is not a purer reading of the specification
but a flag that lies.

### The CI retry loop comes out

`.github/workflows/ci.yml` returns to the single plain run it had before
#317, with a comment recording why the loop stood and why it no longer
earns its keep.

### Verification

- Gate green: 2,053 tests, 100% branch coverage, format/lint/mypy clean.
- Four new tests, two per engine: a seeded session's twins stay twins across
  a reseed (plus the rising-sequence case for the Z-Machine), and the
  entropy path is proved to be the unseeded one, by pinning `urandom` so two
  unseeded streams converge and then failing the test outright if a seeded
  session ever reaches it.
- Corpus sweep: all 44 recordings, 105 warnings, tally-for-tally identical
  to the pre-change baseline. Worth noting what that does and does not
  prove: it compares refusal counts, not whole transcripts. The structural
  argument is the stronger one. Any recording whose game reached a reseed
  would already be non-deterministic today, since today those calls reach
  `os.urandom` whatever the seed, and all 44 replay identically. So none of
  them can be touching this path.

## Checklist

- [x] **The gate passes locally**
- [x] **The PR title is a conventional commit**
- [x] **Spec citations accompany behavior changes** (§2.4, §15 random, §2
      remarks, and Glulx: The Random Number Generator, each beside the
      deviation and its reason)
- [x] **The corpus still replays** (see above)
- [x] **`entharion/` is untouched**
